### PR TITLE
Add feature that a space can be booked

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem 'sinatra'
 gem 'sinatra-contrib'
+gem 'sinatra-session'
 gem 'rspec'
 gem 'capybara'
 gem 'webrick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,8 @@ GEM
       rack-protection (= 2.1.0)
       sinatra (= 2.1.0)
       tilt (~> 2.0)
+    sinatra-session (1.0.0)
+      sinatra (>= 1.0)
     tilt (2.0.10)
     webrick (1.7.0)
     xpath (3.2.0)
@@ -71,6 +73,7 @@ DEPENDENCIES
   rspec
   sinatra
   sinatra-contrib
+  sinatra-session
   webrick
 
 BUNDLED WITH

--- a/app.rb
+++ b/app.rb
@@ -4,6 +4,7 @@ require './lib/space'
 require './lib/owner'
 
 class BnB < Sinatra::Base
+  enable :sessions
   configure :development do
     register Sinatra::Reloader
   end
@@ -17,26 +18,19 @@ class BnB < Sinatra::Base
     erb(:spaces)
   end
 
-  get '/booked' do
-    erb(:booked)
-  end
 
   post '/spaces' do
-    p "This is the params #{params}"
-    p "This is the params[:space_name] #{params[:space_name]}"
-    Space.create(name: params[:space_name]) # might need to update this
+    Space.create(name: params[:space_name]) 
     redirect '/spaces'
   end
 
   post '/book_space' do
-    p "This is the params[:space_name] #{params[:space_name]}" # this works. returns the space name 
-    # here call the update Spaces method and pass in the returned space name e.g. Windsor Castle
-    connection = PG.connect(dbname: 'makersbnb')
-    connection.exec_params(
-    "UPDATE spaces SET available = 'f' WHERE name = $1",
-    [ params[:space_name] ]
-    )
+    Space.book(name: params[:space_name])
     redirect '/booked'
+  end
+
+  get '/booked' do
+    erb(:booked)
   end
 
   get '/add_space' do

--- a/app.rb
+++ b/app.rb
@@ -4,7 +4,8 @@ require './lib/space'
 require './lib/owner'
 
 class BnB < Sinatra::Base
-  enable :sessions
+  enable :sessions unless test?
+    set :session_secret, "secret"
   configure :development do
     register Sinatra::Reloader
   end
@@ -26,10 +27,12 @@ class BnB < Sinatra::Base
 
   post '/book_space' do
     Space.book(name: params[:space_name])
+    session[:booked_space] = params[:space_name]
     redirect '/booked'
   end
 
   get '/booked' do
+    @booked_space = session[:booked_space]
     erb(:booked)
   end
 

--- a/app.rb
+++ b/app.rb
@@ -28,6 +28,12 @@ class BnB < Sinatra::Base
     redirect '/spaces'
   end
 
+  post '/book_space' do
+    p "This is the params[:space_name] #{params[:space_name]}" # this works. returns the space name 
+    # here call the update Spaces method and pass in the returned space name e.g. Windsor Castle
+    redirect '/booked'
+  end
+
   get '/add_space' do
     erb(:list_a_space)
   end

--- a/app.rb
+++ b/app.rb
@@ -31,6 +31,11 @@ class BnB < Sinatra::Base
   post '/book_space' do
     p "This is the params[:space_name] #{params[:space_name]}" # this works. returns the space name 
     # here call the update Spaces method and pass in the returned space name e.g. Windsor Castle
+    connection = PG.connect(dbname: 'makersbnb')
+    connection.exec_params(
+    "UPDATE spaces SET available = 'f' WHERE name = $1",
+    [ params[:space_name] ]
+    )
     redirect '/booked'
   end
 

--- a/lib/space.rb
+++ b/lib/space.rb
@@ -2,12 +2,13 @@ require 'pg'
 
 class Space 
 
-  attr_reader :id, :name, :available
+  attr_reader :id, :name, :available, :owner_name
 
-  def initialize(id:, name:, available:)
+  def initialize(id:, name:, available:, owner_name:)
     @id = id
     @name = name
     @available = available
+    @owner_name = owner_name
   end
 
   def self.all
@@ -18,7 +19,7 @@ class Space
     end
     result = connection.exec("SELECT * FROM spaces")
     result.map { |space|  #update the rest of the app
-    Space.new(id: space["id"], name: space["name"], available: space["available"])
+    Space.new(id: space["id"], name: space["name"], available: space["available"], owner_name: space['owner_name'])
     }
   end
 
@@ -29,7 +30,20 @@ class Space
     else
       connection = PG.connect(dbname: "makersbnb")
     end
-      result = connection.exec("INSERT INTO spaces (name, available) VALUES('#{name}', true) RETURNING id, name, available;") 
-      Space.new(id: result[0]['id'], name: result[0]['name'], available: result[0]['available'])
+      result = connection.exec("INSERT INTO spaces (name, available) VALUES('#{name}', true) RETURNING id, name, available, owner_name;") 
+      Space.new(id: result[0]['id'], name: result[0]['name'], available: result[0]['available'], owner_name: result[0]['owner_name'])
+  end
+
+  def self.book(name:)
+    if ENV['ENVIRONMENT'] == 'test'
+      connection = PG.connect(dbname: "makersbnb_test")
+    else
+      connection = PG.connect(dbname: "makersbnb")
+    end
+    result = connection.exec_params(
+    "UPDATE spaces SET available = 'f' WHERE name = $1 RETURNING id, name, available, owner_name;",
+    [name]
+    ) 
+    Space.new(id: result[0]['id'], name: result[0]['name'], available: result[0]['available'], owner_name: result[0]['owner_name'])
   end
 end

--- a/spec/features/booked_spec.rb
+++ b/spec/features/booked_spec.rb
@@ -11,7 +11,7 @@ feature "Updating available status" do
         visit('/spaces')
         expect(page).to have_content "Windsor Castle"
         within_fieldset("Windsor Castle") do
-          click_on('book') #? 
+          click_on('book')
         end
         expect(page).to have_content "Room Requested"
     end

--- a/spec/features/booked_spec.rb
+++ b/spec/features/booked_spec.rb
@@ -4,3 +4,14 @@ feature "booking a room" do
         expect(page).to have_content "Room Requested"
     end
 end
+
+feature "Updating available status" do
+    scenario "A guest can book a room" do
+        space = Space.create(name: "Tudor house")
+        visit('/spaces')
+        expect(page).to have_content "Tudor house"
+        within_fieldset("Tudor house") do
+        click_button "Request booking"
+        end
+    end
+end

--- a/spec/features/booked_spec.rb
+++ b/spec/features/booked_spec.rb
@@ -11,7 +11,8 @@ feature "Updating available status" do
         visit('/spaces')
         expect(page).to have_content "Windsor Castle"
         within_fieldset("Windsor Castle") do
-          click_button "Request booking"
+          click_on('book') #? 
         end
+        expect(page).to have_content "Room Requested"
     end
 end

--- a/spec/features/booked_spec.rb
+++ b/spec/features/booked_spec.rb
@@ -7,11 +7,11 @@ end
 
 feature "Updating available status" do
     scenario "A guest can book a room" do
-        space = Space.create(name: "Tudor house")
+        space = Space.create(name: "Windsor Castle")
         visit('/spaces')
-        expect(page).to have_content "Tudor house"
-        within_fieldset("Tudor house") do
-        click_button "Request booking"
+        expect(page).to have_content "Windsor Castle"
+        within_fieldset("Windsor Castle") do
+          click_button "Request booking"
         end
     end
 end

--- a/spec/features/list_a_space_spec.rb
+++ b/spec/features/list_a_space_spec.rb
@@ -4,4 +4,5 @@ feature 'List a space' do
     fill_in('space', :with => "room1")
     click_button 'submit'
     expect(page).to have_content "room1"
-    
+  end    
+end

--- a/spec/features/list_a_space_spec.rb
+++ b/spec/features/list_a_space_spec.rb
@@ -1,7 +1,7 @@
 feature 'List a space' do
   scenario 'I would like to be able to list a space and name' do
-    visit('/add_rooms')
-    fill_in('space', :with => "room1")
+    visit('/add_space')
+    fill_in('space_name', :with => "room1")
     click_button 'submit'
     expect(page).to have_content "room1"
   end    

--- a/spec/features/room_spec.rb
+++ b/spec/features/room_spec.rb
@@ -1,5 +1,6 @@
 feature 'viewing a room' do
   scenario 'user will be able to view a room on the site' do
+    space = Space.create(name: "Windsor Castle")
     visit '/spaces'
     expect(page).to have_content('Windsor Castle')
   end

--- a/spec/features/submitting_spaces_spec.rb
+++ b/spec/features/submitting_spaces_spec.rb
@@ -1,6 +1,6 @@
 feature 'Inputting a space' do
   scenario 'Creating spaces' do
-    visit('/spaces')
+    visit('/add_space')
     fill_in('space_name', :with => "room1")
     click_button 'submit'
     expect(page).to have_content "room1"

--- a/spec/space_spec.rb
+++ b/spec/space_spec.rb
@@ -17,12 +17,14 @@ describe Space do
   end
 
   describe '.book' do
-    it 'should set availability of spaces to false' do
+    it 'books a space' do
       space = Space.create(name: 'The Hilton')
-      persisted_data = PG.connect(dbname: 'makersbnb_test').query("SELECT * FROM spaces WHERE id = #{space.id};")
-      booked_space = Space.book(id: space.id)
-      expect(space.name).to eq 'The Hilton'
-      expect(space.available).to eq 'f'
+      updated_space = Space.book(name: space.name)
+      
+      expect(updated_space).to be_a Space
+      expect(updated_space.id).to eq space.id
+      expect(updated_space.name).to eq 'The Hilton'
+      expect(updated_space.available).to eq 'f'
     end    
   end
   

--- a/spec/space_spec.rb
+++ b/spec/space_spec.rb
@@ -16,13 +16,13 @@ describe Space do
     end
   end
 
-  describe '#book' do
-    
+  describe '.book' do
     it 'should set availability of spaces to false' do
-      pending
-      conn = PG.connect(dbname: 'makersbnb_test')
-      spaces = Space.update
-      expect('Windsor Castle').to updated_with(false) # this is sudo code
+      space = Space.create(name: 'The Hilton')
+      persisted_data = PG.connect(dbname: 'makersbnb_test').query("SELECT * FROM spaces WHERE id = #{space.id};")
+      booked_space = Space.book(id: space.id)
+      expect(space.name).to eq 'The Hilton'
+      expect(space.available).to eq 'f'
     end    
   end
   

--- a/views/booked.erb
+++ b/views/booked.erb
@@ -1,6 +1,7 @@
 <body style= 'background-color: #80ced6'>
 <div style='position:absolute; top: 50%; left:50%; transform:translate(-50%, -50%)'>
 <h1 style='font-size: 50px'> Room Requested! </h1>
+<div> You have booked: <%=@booked_space %> </div>
 
 <button style= 'padding:30px; width:550px'><a href="/"> Back to Homepage </button>
 </div>

--- a/views/list_a_space.erb
+++ b/views/list_a_space.erb
@@ -1,4 +1,4 @@
 <form action="/spaces" method="post">
 <input type="text" name="Owner Name" placeholder="Name">
-<input type="text" name="space" placeholder="Space">
+<input type="text" name="space_name" placeholder="Space">
 <input type="submit" value="submit">

--- a/views/spaces.erb
+++ b/views/spaces.erb
@@ -5,15 +5,16 @@ font-family: Permanent Marker, cursive; position:absolute; left: 03%'>MakersBnB<
 
 <div style='position:absolute; top: 50%; left:50%; transform:translate(-50%, -50%)'>
 <h1 style='font-size: 50px' > Viewing Available rooms! </h1>
-<form action="/spaces" method="post">
-<h3 style='font-family: Balsamiq Sans, cursive;
-font-family: Permanent Marker, cursive; position:absolute; left: 03%'>Room for list:</h3>
-</form>
 <ol>
   <% @spaces.each do |room| %>
     <fieldset id='<%=room.name%>'>
-    <li><%= room.name %><img src= https://www.gannett-cdn.com/-mm-/05b227ad5b8ad4e9dcb53af4f31d7fbdb7fa901b/c=0-64-2119-1259/local/-/media/USATODAY/USATODAY/2014/08/13/1407953244000-177513283.jpg alt="our bnb"
-     style="height:100px; width:100px; border-radius:80px; top:10%"><button type="button" name="book" class="btn btn-primary btn-lg" data-bs-toggle="button" autocomplete="off"><a href="/booked">Request booking </button> </li>
+    <li><%= room.name %>
+    <img src= https://www.gannett-cdn.com/-mm-/05b227ad5b8ad4e9dcb53af4f31d7fbdb7fa901b/c=0-64-2119-1259/local/-/media/USATODAY/USATODAY/2014/08/13/1407953244000-177513283.jpg alt="our bnb"
+     style="height:100px; width:100px; border-radius:80px; top:10%">
+    <form action="/book_space" method="post">
+    <input type="submit" id="book" name="book" value="Book Space">
+    <input type="hidden" id="space_name" name="space_name" value="<%= room.name %>" > 
+    </form> 
     </fieldset> 
  <% end %>
 </ol>

--- a/views/spaces.erb
+++ b/views/spaces.erb
@@ -11,9 +11,11 @@ font-family: Permanent Marker, cursive; position:absolute; left: 03%'>Room for l
 </form>
 <ol>
   <% @spaces.each do |room| %>
+    <fieldset id='<%=room.name%>'>
     <li><%= room.name %><img src= https://www.gannett-cdn.com/-mm-/05b227ad5b8ad4e9dcb53af4f31d7fbdb7fa901b/c=0-64-2119-1259/local/-/media/USATODAY/USATODAY/2014/08/13/1407953244000-177513283.jpg alt="our bnb"
      style="height:100px; width:100px; border-radius:80px; top:10%"><button type="button" class="btn btn-primary btn-lg" data-bs-toggle="button" autocomplete="off"><a href="/booked">Request booking </button> </li>
-  <% end %>
+    </fieldset> 
+ <% end %>
 </ol>
 <button style= 'font-size: 30px; padding:30px; width:250px; font-family: Balsamiq Sans, cursive; border-radius: 80px; position:absolute;left:30%'><a href="/"> Back to Homepage </button>
 </div>

--- a/views/spaces.erb
+++ b/views/spaces.erb
@@ -11,7 +11,7 @@ font-family: Permanent Marker, cursive; position:absolute; left: 03%'>Room for l
 </form>
 <ol>
   <% @spaces.each do |room| %>
-    <li><%= room %><img src= https://www.gannett-cdn.com/-mm-/05b227ad5b8ad4e9dcb53af4f31d7fbdb7fa901b/c=0-64-2119-1259/local/-/media/USATODAY/USATODAY/2014/08/13/1407953244000-177513283.jpg alt="our bnb"
+    <li><%= room.name %><img src= https://www.gannett-cdn.com/-mm-/05b227ad5b8ad4e9dcb53af4f31d7fbdb7fa901b/c=0-64-2119-1259/local/-/media/USATODAY/USATODAY/2014/08/13/1407953244000-177513283.jpg alt="our bnb"
      style="height:100px; width:100px; border-radius:80px; top:10%"><button type="button" class="btn btn-primary btn-lg" data-bs-toggle="button" autocomplete="off"><a href="/booked">Request booking </button> </li>
   <% end %>
 </ol>

--- a/views/spaces.erb
+++ b/views/spaces.erb
@@ -13,7 +13,7 @@ font-family: Permanent Marker, cursive; position:absolute; left: 03%'>Room for l
   <% @spaces.each do |room| %>
     <fieldset id='<%=room.name%>'>
     <li><%= room.name %><img src= https://www.gannett-cdn.com/-mm-/05b227ad5b8ad4e9dcb53af4f31d7fbdb7fa901b/c=0-64-2119-1259/local/-/media/USATODAY/USATODAY/2014/08/13/1407953244000-177513283.jpg alt="our bnb"
-     style="height:100px; width:100px; border-radius:80px; top:10%"><button type="button" class="btn btn-primary btn-lg" data-bs-toggle="button" autocomplete="off"><a href="/booked">Request booking </button> </li>
+     style="height:100px; width:100px; border-radius:80px; top:10%"><button type="button" name="book" class="btn btn-primary btn-lg" data-bs-toggle="button" autocomplete="off"><a href="/booked">Request booking </button> </li>
     </fieldset> 
  <% end %>
 </ol>


### PR DESCRIPTION
All rspec tests are passing. 
I've added a .book class method, building on Mo's code from this morning (thanks Mo). I've added a new post route '/book_space' to app.rb that calls that .book method, taking params[:space_name] as it's argument. This means that on the spaces page, when you click the "request room" button next to a space name, it updates the database to change that room's availability to false 🥳.

I've also used sessions show the name of the room that has just been booked on the booked page. I had to add a new gem to the Gemfile to make this work, 'sinatra-session', so you will probably need to run `bundle` again to make it work. 